### PR TITLE
feat: allow non-admin config tokens to rotate using rotation API

### DIFF
--- a/testdata/rotate_current_token_fail_to_create_access_token.json
+++ b/testdata/rotate_current_token_fail_to_create_access_token.json
@@ -24,6 +24,7 @@
   "/api/v4/users/1": {
     "id": 1,
     "username": "ilijamt",
-    "name": "Ilija Matoski"
+    "name": "Ilija Matoski",
+    "is_admin": true
   }
 }

--- a/testdata/rotate_current_token_non_admin.json
+++ b/testdata/rotate_current_token_non_admin.json
@@ -25,9 +25,9 @@
     "id": 1,
     "username": "ilijamt",
     "name": "Ilija Matoski",
-    "is_admin": true
+    "is_admin": false
   },
-  "/api/v4/users/1/personal_access_tokens": {
+  "/api/v4/personal_access_tokens/1/rotate": {
     "id": 3,
     "name": "mytoken",
     "revoked": false,


### PR DESCRIPTION
Initial attempt at catching non-admin users and using the token rotation API

Rotation tested!

```console
[tmcneely@local vault-plugin-secrets-gitlab]$ vault write gitlab/config base_url=https://gitlab.company.com auto_rotate_token=true token=$GITLAB_TOKEN
WARNING! The following warnings were returned from Vault:

  * auto_rotate_token not specified setting to 24h0m0s

Key                          Value
---                          -----
auto_rotate_before           24h0m0s
auto_rotate_token            true
base_url                     https://gitlab.company.com
revoke_auto_rotated_token    false
token_expires_at             n/a
token_id                     0
token_sha1_hash              2bc4ea551b76c56813aea32fcbd1a47c78795256

[tmcneely@local vault-plugin-secrets-gitlab]$ vault read gitlab/config/rotate
Key                          Value
---                          -----
auto_rotate_before           24h0m0s
auto_rotate_token            true
base_url                     https://gitlab.company.com
revoke_auto_rotated_token    false
token_expires_at             2025-05-23T00:00:00Z
token_id                     5748
token_sha1_hash              ef04d0bf1453f49bbb640606210bc91fc5bb2d95
```

I was going to add acceptance testing, but it doesn't look like that is very far along yet. ;)

Closes #89 