### PR TITLE
Draft: fix: auto_rotate_before needs to be longer than config token duration

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -82,8 +82,9 @@ type Backend struct {
 	roleLocks []*locksutil.LockEntry
 }
 
+// This function runs every minute, use with caution
 func (b *Backend) periodicFunc(ctx context.Context, request *logical.Request) error {
-	b.Logger().Debug("Periodic action executing")
+	// b.Logger().Debug("Periodic action executing")
 
 	if !b.WriteSafeReplicationState() {
 		return nil
@@ -103,7 +104,7 @@ func (b *Backend) periodicFunc(ctx context.Context, request *logical.Request) er
 		return nil
 	}
 
-	// If we need to autorotate the token, initiate the procedure to autorotate the token
+	// If we need to auto-rotate the token, initiate the procedure to auto-rotate the token
 	if config.AutoRotateToken {
 		err = errors.Join(err, b.checkAndRotateConfigToken(ctx, request, config))
 	}
@@ -121,7 +122,7 @@ func (b *Backend) updateMainTokenExpiryTime(ctx context.Context, request *logica
 	}
 
 	if config.TokenExpiresAt.IsZero() {
-		b.Logger().Warn("Main token expiry information is empty, updating")
+		b.Logger().Debug("Main token expiry information is empty, updating")
 		var entryToken *EntryToken
 		// we need to fetch the token expiration information
 		entryToken, err = client.CurrentTokenInfo()
@@ -148,7 +149,7 @@ func (b *Backend) updateMainTokenExpiryTime(ctx context.Context, request *logica
 func (b *Backend) Invalidate(ctx context.Context, key string) {
 	b.Logger().Debug("Backend invalidate", "key", key)
 	if key == PathConfigStorage {
-		b.Logger().Warn("Gitlab config changed, reinitializing the gitlab client")
+		b.Logger().Warn("Gitlab config changed, re-initializing the gitlab client")
 		b.lockClientMutex.Lock()
 		defer b.lockClientMutex.Unlock()
 		b.client = nil

--- a/backend.go
+++ b/backend.go
@@ -17,10 +17,10 @@ const (
 	operationPrefixGitlabAccessTokens = "gitlab"
 
 	backendHelp = `
-The Gitlab Access token auth Backend dynamically generates private 
+The Gitlab Access token auth Backend dynamically generates private
 and group tokens.
 
-After mounting this Backend, credentials to manage Gitlab tokens must be configured 
+After mounting this Backend, credentials to manage Gitlab tokens must be configured
 with the "config/" endpoints.
 `
 )
@@ -101,11 +101,6 @@ func (b *Backend) periodicFunc(ctx context.Context, request *logical.Request) er
 
 	if config == nil {
 		return nil
-	}
-
-	// if there is no expiry date on the token fetch it
-	if config.TokenExpiresAt.IsZero() {
-		err = errors.Join(err, b.updateMainTokenExpiryTime(ctx, request, config))
 	}
 
 	// If we need to autorotate the token, initiate the procedure to autorotate the token

--- a/backend.go
+++ b/backend.go
@@ -84,7 +84,7 @@ type Backend struct {
 
 // This function runs every minute, use with caution
 func (b *Backend) periodicFunc(ctx context.Context, request *logical.Request) error {
-	// b.Logger().Debug("Periodic action executing")
+	// b.Logger().Trace("Periodic action executing")
 
 	if !b.WriteSafeReplicationState() {
 		return nil
@@ -122,7 +122,7 @@ func (b *Backend) updateMainTokenExpiryTime(ctx context.Context, request *logica
 	}
 
 	if config.TokenExpiresAt.IsZero() {
-		b.Logger().Debug("Main token expiry information is empty, updating")
+		// b.Logger().Warn("Main token expiry information is empty, updating")
 		var entryToken *EntryToken
 		// we need to fetch the token expiration information
 		entryToken, err = client.CurrentTokenInfo()

--- a/entry_config.go
+++ b/entry_config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	g "github.com/xanzy/go-gitlab"
 )
 
 type EntryConfig struct {
@@ -22,7 +23,7 @@ type EntryConfig struct {
 func (e EntryConfig) LogicalResponseData() map[string]any {
 	var tokenExpiresAt = ""
 	if !e.TokenExpiresAt.IsZero() {
-		tokenExpiresAt = e.TokenExpiresAt.Format(time.RFC3339)
+		tokenExpiresAt = (*g.ISOTime)(&(e.TokenExpiresAt)).String()
 	}
 
 	return map[string]any{

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -34,8 +34,11 @@ func (b *Backend) checkAndRotateConfigToken(ctx context.Context, request *logica
 	var err error
 	b.Logger().Debug("Running checkAndRotateConfigToken")
 
-	if err = b.updateMainTokenExpiryTime(ctx, request, config); err != nil {
-		return err
+	// if there is no expiry date on the token fetch it
+	if config.TokenExpiresAt.IsZero() {
+		if err = b.updateMainTokenExpiryTime(ctx, request, config); err != nil {
+			return err
+		}
 	}
 
 	if time.Until(config.TokenExpiresAt) > config.AutoRotateBefore {

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -32,7 +32,7 @@ func pathConfigTokenRotate(b *Backend) *framework.Path {
 
 func (b *Backend) checkAndRotateConfigToken(ctx context.Context, request *logical.Request, config *EntryConfig) error {
 	var err error
-	b.Logger().Debug("Running checkAndRotateConfigToken")
+	b.Logger().Trace("Running checkAndRotateConfigToken")
 
 	// if there is no expiry date on the token fetch it
 	if config.TokenExpiresAt.IsZero() {
@@ -42,7 +42,7 @@ func (b *Backend) checkAndRotateConfigToken(ctx context.Context, request *logica
 	}
 
 	if time.Until(config.TokenExpiresAt) > config.AutoRotateBefore {
-		b.Logger().Debug("Nothing to do it's not yet time to rotate the token")
+		b.Logger().Trace("Nothing to do it's not yet time to rotate the token")
 		return nil
 	}
 

--- a/testdata/rotate_current_token_fail_to_create_access_token.json
+++ b/testdata/rotate_current_token_fail_to_create_access_token.json
@@ -24,6 +24,7 @@
   "/api/v4/users/1": {
     "id": 1,
     "username": "ilijamt",
-    "name": "Ilija Matoski"
+    "name": "Ilija Matoski",
+    "is_admin": true
   }
 }

--- a/testdata/rotate_current_token_non_admin.json
+++ b/testdata/rotate_current_token_non_admin.json
@@ -25,9 +25,9 @@
     "id": 1,
     "username": "ilijamt",
     "name": "Ilija Matoski",
-    "is_admin": true
+    "is_admin": false
   },
-  "/api/v4/users/1/personal_access_tokens": {
+  "/api/v4/personal_access_tokens/1/rotate": {
     "id": 3,
     "name": "mytoken",
     "revoked": false,


### PR DESCRIPTION
NOTE: this one is built upon #90 since I needed that to do my testing. If we need to, I can rebase this so that they are separate.

Changes:

- Cleans up the minutely debug log messages
- Removes some redundant code
- Adds Token Validation and checks the duration of the config token against the auto_rotate_before, because it needs to be longer or it will rotate the config token every minute.

TODO: Fix unit tests, token validation will require additional mock responses