### PR TITLE
fix: guarantee that correct groupId is resolved

### DIFF
--- a/gitlab_client.go
+++ b/gitlab_client.go
@@ -184,20 +184,13 @@ func (gc *gitlabClient) GetGroupIdByPath(ctx context.Context, path string) (grou
 		gc.logger.Debug("Get group id by path", "path", path, "groupId", groupId, "error", err)
 	}()
 
-	l := &g.ListGroupsOptions{
-		Search: g.Ptr(path),
-	}
-
-	groups, _, err := gc.client.Groups.ListGroups(l, g.WithContext(ctx))
+	group, _, err := gc.client.Groups.GetGroup(path, nil, g.WithContext(ctx))
 	if err != nil {
-		return 0, fmt.Errorf("%v", err)
-	}
-	if len(groups) == 0 {
 		return 0, fmt.Errorf("path '%s' not found: %w", path, errs.ErrInvalidValue)
 	}
-	groupId = groups[0].ID
-	return groupId, nil
 
+	groupId = group.ID
+	return groupId, nil
 }
 
 func (gc *gitlabClient) GitlabClient(ctx context.Context) *g.Client {


### PR DESCRIPTION
Fixes #305 by replacing the upstream API call from `ListGroups` into `GetGroup`. GitLab API supports fetching individual groups via `:id`, which can be an URL-encoded path. By replacing this call, we avoid returning multiple non-related groups when doing `/groups?search=` queries that searches by path and name.

I've tested locally against our self-hosted GitLab instance, now the correct group gets resolved. Also tested with sub-groups to ensure all existing functionality still works. Tested a few negative cases as well (ie. non-existing path etc.).